### PR TITLE
feat: proactively delete session if streaming fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@msquared/pixel-streaming-client",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "ua-parser-js": "^1.0.40",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "Browser client for viewing pixel-streamed content from MSquared events",
   "homepage": "https://github.com/msquared-io/pixel-streaming-client",
   "license": "MIT",

--- a/src/react/use-pixel-streaming.ts
+++ b/src/react/use-pixel-streaming.ts
@@ -90,7 +90,7 @@ export function usePixelStreaming({
       )
       streamingClientRef.current.addEventListener("error", onErrorEvent)
 
-      const config = await streamingClientRef.current.fetchStreamConfig({
+      const config = await streamingClientRef.current.setup({
         projectId,
         worldId,
         forceProvider: StreamProvider.GeforceNow,
@@ -101,13 +101,25 @@ export function usePixelStreaming({
       }
 
       const streamingContainerOrError = await streamingClientRef.current.start({
-        ...(config as { streamId: string; config: GeforceStreamConfig }),
+        ...(config as {
+          streamId: string
+          config: GeforceStreamConfig
+          sessionId: string
+          projectId: string
+          worldId: string
+        }),
         provider: StreamProvider.GeforceNow,
         target: StreamTarget.Embedded,
         container: ref,
       })
 
       if (streamingContainerOrError instanceof StreamingClientError) {
+        if (config) {
+          await streamingClientRef.current.cleanup({
+            reason: streamingContainerOrError,
+            ...config,
+          })
+        }
         throw streamingContainerOrError
       }
     },


### PR DESCRIPTION
This change causes the M2 session to be proactively deleted when a GFN streaming session cannot be started, and includes an appropriate deletion reason string that details the failure to help diagnose such issues.

- Renamed `fetchStreamConfig` to `setup` to simplify and clarify the purpose of that function.
- Added `errors.as` implementation and unit tests to support extracting relevant error information.
- Added `deleteSession` to delete M2 sessions.
- Added `cleanup` to perform cleanup operations if the streaming session fails.