### PR TITLE
fix: browser support check should be state (WP-4527)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Browser client for viewing pixel-streamed content from MSquared events",
   "homepage": "https://github.com/msquared-io/pixel-streaming-client",
   "license": "MIT",

--- a/src/react/use-pixel-streaming.ts
+++ b/src/react/use-pixel-streaming.ts
@@ -30,11 +30,11 @@ type UsePixelStreamingParams = Readonly<{
 }>
 
 type UsePixelStreamingResult = {
+  browserSupport: Record<StreamProvider, boolean> | undefined
   streamState: StreamState
   sessionState: SessionState | undefined
   startStreaming: (params: StartStreamingParams) => void
   stopStreaming: () => void
-  getBrowserSupport: () => Record<StreamProvider, boolean>
 }
 
 export function usePixelStreaming({
@@ -46,6 +46,10 @@ export function usePixelStreaming({
 }: UsePixelStreamingParams): UsePixelStreamingResult {
   const [streamState, setStreamState] = useState<StreamState>(StreamState.Idle)
   const [sessionState, setSessionState] = useState<SessionState | undefined>()
+
+  const [browserSupport, setBrowserSupport] = useState<
+    Record<StreamProvider, boolean> | undefined
+  >(undefined)
 
   const streamingClientRef = useRef<StreamingClient | null>(null)
   const eventHandlersRef = useRef<{
@@ -67,6 +71,8 @@ export function usePixelStreaming({
         clientOptions ?? defaultClientOpts,
       )
     }
+
+    setBrowserSupport(streamingClientRef.current.getBrowserSupport())
 
     return () => {
       stopStreaming()
@@ -170,17 +176,11 @@ export function usePixelStreaming({
     setSessionState(undefined)
   }, [])
 
-  const getBrowserSupport = useCallback(() => {
-    return streamingClientRef.current
-      ? streamingClientRef.current.getBrowserSupport()
-      : ({} as Record<StreamProvider, boolean>)
-  }, [])
-
   return {
-    streamState,
+    browserSupport,
     sessionState,
+    streamState,
     startStreaming,
     stopStreaming,
-    getBrowserSupport,
   }
 }


### PR DESCRIPTION
- return browser support as state in react hook not as a callback
- og implementation was weird as when initially ran it would return no support as the client is not initialised
- this should be deterministic based on client options so makes sense to just run once during setup instead of having a callback passed out
- @mpsq maybe i have missed some subtly as to why it is a callback - can you see if i am doing something wrong here?