### PR TITLE
feat: expose common error codes

### DIFF
--- a/src/gfn/types.ts
+++ b/src/gfn/types.ts
@@ -29,28 +29,26 @@ export declare enum ServerType {
 }
 
 export declare enum TerminationErrorCode {
-  Success = 0x00F20000,
-  
+  Success = 0x00f20000,
   // Common errors returned when a stream terminates.
-  ServerDisconnectedIntended = 0x00F22320, // Game client terminated.
-  ServerDisconnectedUserIdle = 0x00F22324, // No input received from user.
-  ServerDisconnectedAnotherClient = 0x00F2232A, // User started another client.
-  ServerDisconnectedConcurrentSessionLimitExceeded = 0x00F22344,  // User started another session.
-  ServerDisconnectedMultipleLogin = 0x00F22348, // User started another session.
-  ServerDisconnectedMaintenanceMode = 0x00F22349, // Service is entering maintenance.
-  ServerDisconnectedMultipleTab = 0x00F22350, // User started another session in another tab.
-
+  ServerDisconnectedIntended = 0x00f22320, // Game client terminated.
+  ServerDisconnectedUserIdle = 0x00f22324, // No input received from user.
+  ServerDisconnectedAnotherClient = 0x00f2232a, // User started another client.
+  ServerDisconnectedConcurrentSessionLimitExceeded = 0x00f22344, // User started another session.
+  ServerDisconnectedMultipleLogin = 0x00f22348, // User started another session.
+  ServerDisconnectedMaintenanceMode = 0x00f22349, // Service is entering maintenance.
+  ServerDisconnectedMultipleTab = 0x00f22350, // User started another session in another tab.
   // Common errors when starting a stream.
-  NoNetwork = 0xC0F21001, // No network detected.
-  NetworkError = 0xC0F21002, // Network connection failed.
-  RequestLimitExceeded = 0xC0F2210A, // User started too many streams.
-  SessionLimitExceeded = 0xC0F2210B, // User started too many streams.
-  Maintenance = 0xC0F22118, // Service is in maintenance.
-  AppPatching = 0xC0F22129, // The application is being updated.
-  RegionBanned = 0xC0F22135, // The user is in an unsupported region.
-  GuestModeCampaignDisabled = 0xC0F22149, // The application does not support guest mode.
-  InvalidVideoElement = 0xC0F22400, // The supplied video element is invalid.
-  InvalidAudioElement = 0xC0F22401, // The supplied audio element is invalid.
+  NoNetwork = 0xc0f21001, // No network detected.
+  NetworkError = 0xc0f21002, // Network connection failed.
+  RequestLimitExceeded = 0xc0f2210a, // User started too many streams.
+  SessionLimitExceeded = 0xc0f2210b, // User started too many streams.
+  Maintenance = 0xc0f22118, // Service is in maintenance.
+  AppPatching = 0xc0f22129, // The application is being updated.
+  RegionBanned = 0xc0f22135, // The user is in an unsupported region.
+  GuestModeCampaignDisabled = 0xc0f22149, // The application does not support guest mode.
+  InvalidVideoElement = 0xc0f22400, // The supplied video element is invalid.
+  InvalidAudioElement = 0xc0f22401, // The supplied audio element is invalid.
 }
 
 export interface ZoneTable {

--- a/src/gfn/types.ts
+++ b/src/gfn/types.ts
@@ -28,6 +28,31 @@ export declare enum ServerType {
   SecureSignallingPassThrough = 53,
 }
 
+export declare enum TerminationErrorCode {
+  Success = 0x00F20000,
+  
+  // Common errors returned when a stream terminates.
+  ServerDisconnectedIntended = 0x00F22320, // Game client terminated.
+  ServerDisconnectedUserIdle = 0x00F22324, // No input received from user.
+  ServerDisconnectedAnotherClient = 0x00F2232A, // User started another client.
+  ServerDisconnectedConcurrentSessionLimitExceeded = 0x00F22344,  // User started another session.
+  ServerDisconnectedMultipleLogin = 0x00F22348, // User started another session.
+  ServerDisconnectedMaintenanceMode = 0x00F22349, // Service is entering maintenance.
+  ServerDisconnectedMultipleTab = 0x00F22350, // User started another session in another tab.
+
+  // Common errors when starting a stream.
+  NoNetwork = 0xC0F21001, // No network detected.
+  NetworkError = 0xC0F21002, // Network connection failed.
+  RequestLimitExceeded = 0xC0F2210A, // User started too many streams.
+  SessionLimitExceeded = 0xC0F2210B, // User started too many streams.
+  Maintenance = 0xC0F22118, // Service is in maintenance.
+  AppPatching = 0xC0F22129, // The application is being updated.
+  RegionBanned = 0xC0F22135, // The user is in an unsupported region.
+  GuestModeCampaignDisabled = 0xC0F22149, // The application does not support guest mode.
+  InvalidVideoElement = 0xC0F22400, // The supplied video element is invalid.
+  InvalidAudioElement = 0xC0F22401, // The supplied audio element is invalid.
+}
+
 export interface ZoneTable {
   [key: string]: Zone
 }


### PR DESCRIPTION
Expose common error codes returned in the termination callback, and add handling to treat `ServerDisconnectedIntended` as a non-error.