### PR TITLE
fix: raise error if stream does not start due to reaching session limit

### DIFF
--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -1,7 +1,7 @@
 import { invariant } from "../invariant"
 
 import { type API, TerminationErrorCode } from "./types"
-import type { ServerInfo, State } from "./types"
+import type { ServerInfo } from "./types"
 
 export const GFN_SDK_URL =
   "https://sdk.nvidia.com/gfn/client-sdk/1.x/gfn-client-sdk.js"

--- a/src/gfn/types.ts
+++ b/src/gfn/types.ts
@@ -28,6 +28,24 @@ export declare enum ServerType {
   SecureSignallingPassThrough = 53,
 }
 
+export declare enum GFNStreamerState {
+  Unknown = 0,
+  Initializing = 1,
+  Connecting = 2,
+  Streaming = 3,
+  Pausing = 4,
+  Paused = 5,
+  Resuming = 6,
+  Finished = 7,
+}
+
+export declare enum GFNDiagnosticLevel {
+  Debug = 0,
+  Info = 1,
+  Warning = 2,
+  Error = 3,
+}
+
 export declare enum TerminationErrorCode {
   Success = 0x00f20000,
   // Common errors returned when a stream terminates.
@@ -119,6 +137,14 @@ export declare class API {
       (
         event: "terminated",
         callback: (e: { reason: number; code?: number }) => void,
+      ): void
+      (
+        event: "diagnostic",
+        callback: (e: {
+          level?: number
+          code?: number
+          message?: string
+        }) => void,
       ): void
     }
   }

--- a/src/gfn/types.ts
+++ b/src/gfn/types.ts
@@ -28,24 +28,6 @@ export declare enum ServerType {
   SecureSignallingPassThrough = 53,
 }
 
-export declare enum GFNStreamerState {
-  Unknown = 0,
-  Initializing = 1,
-  Connecting = 2,
-  Streaming = 3,
-  Pausing = 4,
-  Paused = 5,
-  Resuming = 6,
-  Finished = 7,
-}
-
-export declare enum GFNDiagnosticLevel {
-  Debug = 0,
-  Info = 1,
-  Warning = 2,
-  Error = 3,
-}
-
 export declare enum TerminationErrorCode {
   Success = 0x00f20000,
   // Common errors returned when a stream terminates.


### PR DESCRIPTION
Raise an error to the caller if the stream cannot start due to the user hitting the concurrent session or session start rate limit.

Hook into the `diagnostic` event as that's the only way the GFN SDK raises this condition. (They do _not_ appear as stream `termination` events presumably as the stream never started.)