### PR TITLE
fix: correctly export TerminationErrorCode enum

### DIFF
--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -1,7 +1,7 @@
 import { invariant } from "../invariant"
 
-import { type API, TerminationErrorCode } from "./types"
-import type { ServerInfo } from "./types"
+import { TerminationErrorCode } from "./types"
+import type { API, ServerInfo } from "./types"
 
 export const GFN_SDK_URL =
   "https://sdk.nvidia.com/gfn/client-sdk/1.x/gfn-client-sdk.js"

--- a/src/gfn/types.ts
+++ b/src/gfn/types.ts
@@ -28,7 +28,7 @@ export declare enum ServerType {
   SecureSignallingPassThrough = 53,
 }
 
-export declare enum TerminationErrorCode {
+export enum TerminationErrorCode {
   Success = 0x00f20000,
   // Common errors returned when a stream terminates.
   ServerDisconnectedIntended = 0x00f22320, // Game client terminated.


### PR DESCRIPTION
Fix build issue with `TerminationErrorCode` not being exported correctly.