### PR TITLE
fix: reset client before starting a new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Browser client for viewing pixel-streamed content from MSquared events",
   "homepage": "https://github.com/msquared-io/pixel-streaming-client",
   "license": "MIT",

--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -75,7 +75,12 @@ class GFNClient {
       resolution.width = 1280
     }
 
-    this.player?.remove()
+    // Remove existing player element if it exists and reset the client state.
+    if (this.player) {
+      this.player?.remove()
+      this.cancel()
+    }
+
     this.player = document.createElement("div")
     this.player.setAttribute("id", GEFORCE_PLAYER_ELEMENT_ID)
     this.player.setAttribute(
@@ -98,6 +103,10 @@ class GFNClient {
     } catch (cause) {
       return new GFNClientError("failed to start stream", { cause })
     }
+  }
+
+  cancel() {
+    globalThis.GFN.streamer.cancel()
   }
 
   stop() {

--- a/src/gfn/types.ts
+++ b/src/gfn/types.ts
@@ -113,6 +113,7 @@ export declare class API {
         fps: number
       }
     }) => Promise<void>
+    cancel: () => void
     stop: () => void
     on: {
       (event: "started", callback: () => void): void


### PR DESCRIPTION
Reset existing client setup attempt or active session if the client requests a new session.

This is based on feedback from nVidia regarding issues starting multiple streams within one session.