### PR TITLE
fix: nonce reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Browser client for viewing pixel-streamed content from MSquared events",
   "homepage": "https://github.com/msquared-io/pixel-streaming-client",
   "license": "MIT",

--- a/src/client.ts
+++ b/src/client.ts
@@ -418,8 +418,6 @@ export class StreamingClient extends TypedEventTarget<StreamingClientEvents> {
 
         const gfnClient = await getOrInitClient({
           settings: this.gdnSettings,
-          cmsId: Number.parseInt(config.cmsId),
-          nonce: config.nonce,
         })
 
         if (errors.is(gfnClient)) {
@@ -442,7 +440,10 @@ export class StreamingClient extends TypedEventTarget<StreamingClientEvents> {
           },
         })
 
-        const result = await gfnClient.start(element)
+        const result = await gfnClient.start(element, {
+          cmsId: Number.parseInt(config.cmsId),
+          nonce: config.nonce,
+        })
         if (errors.is(result)) {
           onTerminated(result)
           return result

--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -45,7 +45,9 @@ type Config = {
     catalogClientId: string
     partnerId: string
   }
+}
 
+type Auth = {
   cmsId: number
   nonce: string
 }
@@ -62,7 +64,12 @@ class GFNClient {
     readonly serverInfo: ServerInfo,
   ) {}
 
-  async start(container: HTMLElement): Promise<GFNClientError | undefined> {
+  async start(
+    container: HTMLElement,
+    auth: Auth,
+  ): Promise<GFNClientError | undefined> {
+    await globalThis.GFN.auth.loginWithNonce(auth.nonce, auth.cmsId)
+
     const token = globalThis.GFN.auth.guestUser?.idToken
     invariant(token, "guestUser ID token should exist")
 
@@ -92,7 +99,7 @@ class GFNClient {
     try {
       await globalThis.GFN.streamer.start({
         server: this.serverInfo.defaultZone.address,
-        appId: this.config.cmsId,
+        appId: auth.cmsId,
         windowElementId: GEFORCE_PLAYER_ELEMENT_ID,
         streamParams: {
           width: resolution.width,
@@ -158,7 +165,6 @@ export async function initClient(
       new globalThis.GFN.Settings(config.settings),
     )
     const server = await globalThis.GFN.server.getServerInfo()
-    await globalThis.GFN.auth.loginWithNonce(config.nonce, config.cmsId)
     globalThis.GFN.settings.vpcId = server.vpcId
 
     client = new GFNClient(config, server)


### PR DESCRIPTION
Fix a bug whereby 'nonce' values were only being set on first load, such that attempts to launch a new streaming session would fail due to a new value not being provided.

With this change, the new value is provided for every attempt to start a new streaming session.