### PR TITLE
chore: release v0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Browser client for viewing pixel-streamed content from MSquared events",
   "homepage": "https://github.com/msquared-io/pixel-streaming-client",
   "license": "MIT",


### PR DESCRIPTION
Bump version to v0.10.1, as v0.10.0 was unpublished hence cannot be replaced.