### PR TITLE
fix: don't clear session when auth token changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Browser client for viewing pixel-streamed content from MSquared events",
   "homepage": "https://github.com/msquared-io/pixel-streaming-client",
   "license": "MIT",

--- a/src/client.ts
+++ b/src/client.ts
@@ -312,6 +312,10 @@ export class StreamingClient extends TypedEventTarget<StreamingClientEvents> {
     }
   }
 
+  setAuthToken(token: Token): void {
+    this.sessionClient.setAuthToken(token)
+  }
+
   async setup({
     projectId,
     worldId,

--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -113,12 +113,10 @@ class GFNClient {
   }
 
   cancel() {
-    console.trace("Cancelling GFN stream")
     globalThis.GFN.streamer.cancel()
   }
 
   stop() {
-    console.trace("Stopping GFN stream")
     globalThis.GFN.streamer.stop()
   }
 

--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -113,10 +113,12 @@ class GFNClient {
   }
 
   cancel() {
+    console.trace("Cancelling GFN stream")
     globalThis.GFN.streamer.cancel()
   }
 
   stop() {
+    console.trace("Stopping GFN stream")
     globalThis.GFN.streamer.stop()
   }
 

--- a/src/react/use-pixel-streaming.ts
+++ b/src/react/use-pixel-streaming.ts
@@ -57,25 +57,31 @@ export function usePixelStreaming({
     onErrorEvent: (error: StreamingClientErrorEvent) => void
   } | null>(null)
 
-  useEffect(() => {
-    const defaultClientOpts = {
-      auth: {
-        token: authToken,
-        organizationId,
-      },
-    }
+useEffect(() => {
+  if (streamingClientRef.current && authToken) {
+    streamingClientRef.current.setAuthToken(authToken)
+  }
+}, [authToken])
 
-    if (!streamingClientRef.current) {
-      streamingClientRef.current = new StreamingClient(
-        clientOptions ?? defaultClientOpts,
-      )
-    }
+useEffect(() => {
+  const defaultClientOpts = {
+    auth: {
+      token: authToken,
+      organizationId,
+    },
+  }
 
-    return () => {
-      stopStreaming()
-      streamingClientRef.current = null
-    }
-  }, [organizationId, authToken, clientOptions])
+  if (!streamingClientRef.current) {
+    streamingClientRef.current = new StreamingClient(
+      clientOptions ?? defaultClientOpts,
+    )
+  }
+
+  return () => {
+    stopStreaming()
+    streamingClientRef.current = null
+  }
+}, [organizationId, clientOptions]) // Removed authToken and organizationId from dependencies
 
   const startStreaming = useCallback(
     async ({ streamTarget, onError = () => {} }: StartStreamingParams) => {

--- a/src/react/use-pixel-streaming.ts
+++ b/src/react/use-pixel-streaming.ts
@@ -49,6 +49,7 @@ export function usePixelStreaming({
 }: UsePixelStreamingParams): UsePixelStreamingResult {
   const [streamState, setStreamState] = useState<StreamState>(StreamState.Idle)
   const [sessionState, setSessionState] = useState<SessionState | undefined>()
+  const [token, setToken] = useState<string>(authToken)
 
   const streamingClientRef = useRef<StreamingClient | null>(null)
   const eventHandlersRef = useRef<{
@@ -57,31 +58,33 @@ export function usePixelStreaming({
     onErrorEvent: (error: StreamingClientErrorEvent) => void
   } | null>(null)
 
-useEffect(() => {
-  if (streamingClientRef.current && authToken) {
-    streamingClientRef.current.setAuthToken(authToken)
-  }
-}, [authToken])
+  useEffect(() => {
+    if (streamingClientRef.current && authToken) {
+      streamingClientRef.current.setAuthToken(authToken)
+    } else {
+      setToken(authToken)
+    }
+  }, [authToken])
 
-useEffect(() => {
-  const defaultClientOpts = {
-    auth: {
-      token: authToken,
-      organizationId,
-    },
-  }
+  useEffect(() => {
+    const defaultClientOpts = {
+      auth: {
+        token: token,
+        organizationId,
+      },
+    }
 
-  if (!streamingClientRef.current) {
-    streamingClientRef.current = new StreamingClient(
-      clientOptions ?? defaultClientOpts,
-    )
-  }
+    if (!streamingClientRef.current) {
+      streamingClientRef.current = new StreamingClient(
+        clientOptions ?? defaultClientOpts,
+      )
+    }
 
-  return () => {
-    stopStreaming()
-    streamingClientRef.current = null
-  }
-}, [organizationId, clientOptions]) // Removed authToken and organizationId from dependencies
+    return () => {
+      stopStreaming()
+      streamingClientRef.current = null
+    }
+  }, [organizationId, clientOptions, token])
 
   const startStreaming = useCallback(
     async ({ streamTarget, onError = () => {} }: StartStreamingParams) => {

--- a/src/react/use-pixel-streaming.ts
+++ b/src/react/use-pixel-streaming.ts
@@ -60,8 +60,10 @@ export function usePixelStreaming({
 
   useEffect(() => {
     if (streamingClientRef.current && authToken) {
+      // We're already streaming, so set token directly to avoid re-init.
       streamingClientRef.current.setAuthToken(authToken)
     } else {
+      // Not streaming yet, so just set token.
       setToken(authToken)
     }
   }, [authToken])

--- a/src/session.ts
+++ b/src/session.ts
@@ -128,6 +128,15 @@ export class SessionClient {
   }
 
   /**
+   * Sets or updates the authentication token used for requests.
+   *
+   * @param token A string token or a function that returns a string or a Promise resolving to a string.
+   */
+  public setAuthToken(token: Token) : void {
+    this.token = token
+  }
+
+  /**
    *  Refreshes an existing Session. This should be called on a regular basis until the session state becomes `READY`,
    *  at which point the streaming configuration data will be available.
    *

--- a/src/session.ts
+++ b/src/session.ts
@@ -132,7 +132,7 @@ export class SessionClient {
    *
    * @param token A string token or a function that returns a string or a Promise resolving to a string.
    */
-  public setAuthToken(token: Token) : void {
+  public setAuthToken(token: Token): void {
     this.token = token
   }
 


### PR DESCRIPTION
Prevent case whereby streaming was incorrectly stopped when the `authToken` value was changed.