### PR TITLE
feat: make GFN SDK version optionally configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@msquared/pixel-streaming-client",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "ua-parser-js": "^1.0.41",

--- a/src/client.ts
+++ b/src/client.ts
@@ -44,6 +44,8 @@ export type GDNSettings = {
   catalogClientId: string
   /** Partner ID for service integration */
   partnerId: string
+  /** Version number for overriding the default version of GFN */
+  versionNumber?: string
 }
 
 /** Default GDN configuration settings */

--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -6,10 +6,8 @@ import { type API, type ServerInfo, TerminationErrorCode } from "./types"
 const DEFAULT_GFN_SDK_VERSION_NUMBER = "1.1.39"
 
 function gfnSdkUrl(versionNumber: string | undefined) {
-  if (!versionNumber) {
-    versionNumber = DEFAULT_GFN_SDK_VERSION_NUMBER
-  }
-  return `https://sdk.nvidia.com/gfn/client-sdk/${versionNumber}/gfn-client-sdk.js`
+  let version = versionNumber ?? DEFAULT_GFN_SDK_VERSION_NUMBER
+  return `https://sdk.nvidia.com/gfn/client-sdk/${version}/gfn-client-sdk.js`
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -3,9 +3,14 @@ import { invariant } from "../invariant"
 import { type API, type ServerInfo, TerminationErrorCode } from "./types"
 
 // HACK: Temporary downgrade to 1.1.39 due to suspected tab focus issue in 1.1.40
-export const GFN_SDK_URL =
-  "https://sdk.nvidia.com/gfn/client-sdk/1.1.39/gfn-client-sdk.js"
-//"https://sdk.nvidia.com/gfn/client-sdk/1.x/gfn-client-sdk.js"
+const DEFAULT_GFN_SDK_VERSION_NUMBER = "1.1.39"
+
+function gfnSdkUrl(versionNumber: string | undefined) {
+  if (!versionNumber) {
+    versionNumber = DEFAULT_GFN_SDK_VERSION_NUMBER
+  }
+  return `https://sdk.nvidia.com/gfn/client-sdk/${versionNumber}/gfn-client-sdk.js`
+}
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 declare namespace globalThis {
@@ -45,6 +50,7 @@ type Config = {
     clientId: string
     catalogClientId: string
     partnerId: string
+    versionNumber?: string
   }
 }
 
@@ -159,7 +165,7 @@ export async function initClient(
     return GFNClientAlreadyInitialized
   }
 
-  await loadGFNOnce()
+  await loadGFNOnce(config.settings.versionNumber)
 
   try {
     await globalThis.GFN.initialize(
@@ -193,11 +199,11 @@ export async function getOrInitClient(
   return initClient(config)
 }
 
-function loadGFNOnce() {
+function loadGFNOnce(gfnVersionOverride: string | undefined) {
   if (!globalThis.GFN) {
     return new Promise<void>((resolve) => {
       const script = document.createElement("script")
-      script.src = GFN_SDK_URL
+      script.src = gfnSdkUrl(gfnVersionOverride)
       script.addEventListener("load", function loadListener() {
         resolve()
         script.removeEventListener("load", loadListener)

--- a/src/gfn/index.ts
+++ b/src/gfn/index.ts
@@ -5,7 +5,7 @@ import { type API, type ServerInfo, TerminationErrorCode } from "./types"
 // HACK: Temporary downgrade to 1.1.39 due to suspected tab focus issue in 1.1.40
 const DEFAULT_GFN_SDK_VERSION_NUMBER = "1.1.39"
 
-function gfnSdkUrl(versionNumber: string | undefined) {
+function getGfnScriptUrl(versionNumber: string | undefined) {
   let version = versionNumber ?? DEFAULT_GFN_SDK_VERSION_NUMBER
   return `https://sdk.nvidia.com/gfn/client-sdk/${version}/gfn-client-sdk.js`
 }
@@ -201,7 +201,7 @@ function loadGFNOnce(gfnVersionOverride: string | undefined) {
   if (!globalThis.GFN) {
     return new Promise<void>((resolve) => {
       const script = document.createElement("script")
-      script.src = gfnSdkUrl(gfnVersionOverride)
+      script.src = getGfnScriptUrl(gfnVersionOverride)
       script.addEventListener("load", function loadListener() {
         resolve()
         script.removeEventListener("load", loadListener)


### PR DESCRIPTION
In future scenarios where we may need to rollback to a previous version of GFN.

It would be quicker and easier to expose the version number as an optional configuration that overrides the default set in the package. This will allow users of this client to rollback quicker and faster.