### PR TITLE
fix: session stream state updates (WP-6028)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/pixel-streaming-client",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Browser client for viewing pixel-streamed content from MSquared events",
   "homepage": "https://github.com/msquared-io/pixel-streaming-client",
   "license": "MIT",

--- a/src/react/use-pixel-streaming.ts
+++ b/src/react/use-pixel-streaming.ts
@@ -26,7 +26,7 @@ type UsePixelStreamingParams = Readonly<{
   projectId: string
   worldId: string
   authToken: string
-  clientOptions?: ClientOptions
+  clientOptions?: Omit<ClientOptions, "auth">
 }>
 
 export type UsePixelStreamingResult = {
@@ -173,24 +173,20 @@ export function usePixelStreaming({
   }, [authToken])
 
   useEffect(() => {
-    const defaultClientOpts = {
-      auth: {
-        token: token,
-        organizationId,
-      },
-    }
-
     if (!streamingClientRef.current) {
-      streamingClientRef.current = new StreamingClient(
-        clientOptions ?? defaultClientOpts,
-      )
+      streamingClientRef.current = new StreamingClient({
+        ...clientOptions,
+        auth: { token, organizationId },
+      })
     }
+  }, [organizationId, clientOptions, token])
 
+  useEffect(() => {
     return () => {
       stopStreaming()
       streamingClientRef.current = null
     }
-  }, [organizationId, clientOptions, token, stopStreaming])
+  }, [stopStreaming])
 
   return {
     streamState,


### PR DESCRIPTION
- removes auth option in client options from usePixelStreaming as its duplicated
- remove aggressive use effect cleanup which was leading to events not being propagated properly as the original streaming client is killed